### PR TITLE
feat(api): make host/port configurable and add /models endpoint for O…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 dist/
 wheels/
 *.egg-info
+uv.lock
 
 # Virtual environments
 .venv

--- a/chapito/config.py
+++ b/chapito/config.py
@@ -20,6 +20,9 @@ DEFAULT_VERBOSITY: int = 1
 DEFAULT_CHATBOT: Chatbot = Chatbot.GROK
 DEFAULT_STREAM: bool = False
 
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 5001
+
 
 def create_config_file() -> None:
     copy(SAMPLE_CONFIG_FILE, DEFAULT_CONFIG_PATH)
@@ -33,6 +36,8 @@ class Config:
     verbosity: int = DEFAULT_VERBOSITY
     chatbot: Chatbot = DEFAULT_CHATBOT
     stream: bool = DEFAULT_STREAM
+    host: str = DEFAULT_HOST
+    port: int = DEFAULT_PORT
 
     def __init__(self):
         logging.debug("Initializing config...")
@@ -49,6 +54,8 @@ class Config:
         parser.add_argument("--profile-path", type=str, help="Path to the browser profile")
         parser.add_argument("--user-agent", type=str, help="User agent to use")
         parser.add_argument("--verbosity", type=int, help="Verbosity level")
+        parser.add_argument("--host", type=str, help="Host/IP to bind to")
+        parser.add_argument("--port", type=int, help="Port to listen on")
         args = parser.parse_args()
         self.config_path = args.config or DEFAULT_CONFIG_PATH
         config = configparser.ConfigParser()
@@ -80,5 +87,8 @@ class Config:
             chatbot = DEFAULT_CHATBOT
 
         self.chatbot = Chatbot(chatbot)
+
+        self.host = args.host or config.get("DEFAULT", "host", fallback=DEFAULT_HOST)
+        self.port = args.port or config.getint("DEFAULT", "port", fallback=DEFAULT_PORT)
 
         logging.debug(f"Config initialized: {self.__dict__}")

--- a/chapito/proxy.py
+++ b/chapito/proxy.py
@@ -78,9 +78,10 @@ async def chat_completions(request: ChatRequest):
 
     if not request.messages:
         raise HTTPException(status_code=400, detail="Field 'messages' is missing or empty")
-
-    if len(request.messages) >= 2:
-        logging.debug(f"Last relevant message in request: {request.messages[-2]}")
+        
+    last_revelant_message_position = -2 if len(request.messages) >= 2 else -1
+    if len(request.messages) > 0:
+        logging.debug(f"Last relevant message in request: {request.messages[last_revelant_message_position]}")
 
     index_of_last_message = find_index_from_end(request.messages, last_chat_messages)
     prompt = "\n\n".join(

--- a/chapito/proxy.py
+++ b/chapito/proxy.py
@@ -62,10 +62,10 @@ async def not_found_handler(request: Request, exc: HTTPException):
 async def get_models(): 
     return [
         {
-            "name": "chatipo",
+            "name": "chapito",
             "type": "chat",
             "censored": True,
-            "description": "Chatipo",
+            "description": "Chapito",
             "baseModel": True
         }
     ]

--- a/chapito/proxy.py
+++ b/chapito/proxy.py
@@ -58,6 +58,17 @@ def find_index_from_end(lst: List[Message], values: List[str]) -> int:
 async def not_found_handler(request: Request, exc: HTTPException):
     return JSONResponse(status_code=404, content={"message": "Undefined route", "requested_url": request.url.path})
 
+@app.get("/models")
+async def get_models(): 
+    return [
+        {
+            "name": "chatipo",
+            "type": "chat",
+            "censored": True,
+            "description": "Chatipo",
+            "baseModel": True
+        }
+    ]
 
 @app.post("/chat/completions")
 async def chat_completions(request: ChatRequest):
@@ -68,7 +79,8 @@ async def chat_completions(request: ChatRequest):
     if not request.messages:
         raise HTTPException(status_code=400, detail="Field 'messages' is missing or empty")
 
-    logging.debug(f"Last revelant message in request: {request.messages[-2]}")
+    if len(request.messages) >= 2:
+        logging.debug(f"Last relevant message in request: {request.messages[-2]}")
 
     index_of_last_message = find_index_from_end(request.messages, last_chat_messages)
     prompt = "\n\n".join(
@@ -117,4 +129,7 @@ def init_proxy(driver, send_request_and_get_response: Callable, config: Config) 
     app.state.driver = driver
     app.state.send_request_and_get_response = send_request_and_get_response
     app.state.config = config
-    uvicorn.run(app, host="127.0.0.1", port=5001)
+
+    logging.debug(f"Listening on: {config.host}:{config.port}")
+
+    uvicorn.run(app, host=config.host, port=config.port)

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -11,3 +11,7 @@ chatbot = mistral
 
 # Stream response?
 stream = True
+
+# IP and port the service will listen on
+host = 127.0.0.1
+port = 5001


### PR DESCRIPTION
This PR makes three small but useful changes:

1. **Configurable host and port** – The app can now be configured to listen on a different host and port. By default, it still uses 127.0.0.1:5001, but you can change it if needed (e.g. to 0.0.0.0 for access from other devices in the network – useful when running in a virtual machine)
2. **Add `/models` endpoint** – Some AI tools use /models to check if an API is available, instead of sending a completion request. This helps with compatibility.
3. **Check message count before accessing `messages[-2]`** – Added a condition to avoid an error when there is only one message. Without this check, it would crash in that case.

Let me know if anything needs to be adjusted. Thanks!